### PR TITLE
图片路径在win7上乱码

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -130,7 +130,7 @@ function saveClipboardImageToFileAndGetPath(imagePath, cb) {
 
         });
         powershell.stdout.on('data', function (data) {
-            cb(data.toString().trim());
+            cb(imagePath);
         });
     } else if (platform === 'darwin') {
         // Mac


### PR DESCRIPTION
win7上图片路径乱码，直接使用imagePath，或者使用iconv编码，已修复，并发现一个问题，如果截图在打开vscode之前，粘贴图片会报错，为找到原因